### PR TITLE
Fix: Ability to delete change set that didn't apply

### DIFF
--- a/cf-role-master.stackset.yaml
+++ b/cf-role-master.stackset.yaml
@@ -54,6 +54,7 @@ Resources:
                 Resource: "*"
                 Action:
                   - "cloudformation:CreateChangeSet"
+                  - "cloudformation:DeleteChangeSet"
                   - "cloudformation:DeleteStack"
                   - "cloudformation:DescribeChangeSet"
                   - "cloudformation:DescribeStacks"

--- a/s3-event-handlers/build.sbt
+++ b/s3-event-handlers/build.sbt
@@ -35,6 +35,8 @@ coverageFailOnMinimum := true
 
 enablePlugins(JavaAppPackaging)
 
+addCommandAlias("testcoverage", "; reload; clean; compile; coverage; test; coverageReport; reload")
+
 /**
   * Native Packager config for AWS Lambda:
   * 1.) no top level directory in the zip

--- a/s3-event-handlers/src/main/scala/com/lifeway/cloudops/cloudformation/LambdaStackHandler.scala
+++ b/s3-event-handlers/src/main/scala/com/lifeway/cloudops/cloudformation/LambdaStackHandler.scala
@@ -87,10 +87,7 @@ object LambdaStackHandler {
       eventProcessor <- eventProcessorOr
       eventHandled   <- eventHandlerFun(eventProcessor, eventType, event)
     } yield eventHandled).fold(
-      good => {
-        println("it was good!")
-        good
-      },
+      good => good,
       everyBad => throw new Exception(everyBad.mkString("/n"))
     )
 

--- a/s3-event-handlers/src/main/scala/com/lifeway/cloudops/cloudformation/Types.scala
+++ b/s3-event-handlers/src/main/scala/com/lifeway/cloudops/cloudformation/Types.scala
@@ -40,11 +40,9 @@ case object CreateUpdateEvent extends EventType
 case object DeletedEvent      extends EventType
 
 object EventType {
-  implicit val encoder: Encoder[EventType] = Encoder[EventType] { e =>
-    e match {
-      case CreateUpdateEvent => Json.fromString("CreateUpdateEvent")
-      case DeletedEvent      => Json.fromString("DeletedEvent")
-    }
+  implicit val encoder: Encoder[EventType] = Encoder[EventType] {
+    case CreateUpdateEvent => Json.fromString("CreateUpdateEvent")
+    case DeletedEvent      => Json.fromString("DeletedEvent")
   }
   implicit val decoder: Decoder[EventType] = Decoder[EventType] { c =>
     for {


### PR DESCRIPTION
If a change set is not applied, the automation cannot run again with a changeset by the same name unless the previous change set is first deleted. This occurs more frequently than you might expect, as when somebody submits a change that ultimately no change was needed - you end up with a change set in a fail state since there is no change to apply. The next time this stack is updated, the automation first must delete that change set if it exists before trying to create the new change set to execute.